### PR TITLE
bug fix in getNodes() and getLabels()

### DIFF
--- a/python_api/TextParser_python_api.cpp
+++ b/python_api/TextParser_python_api.cpp
@@ -183,14 +183,15 @@ static PyObject* TextParser_currentNode(PyObject* self, PyObject* args)
 static PyObject* TextParser_getNodes(PyObject* self, PyObject* args)
 {
     PyObject* handle;
-    if(!PyArg_ParseTuple(args, "O", &handle))
+    int oswitch=0;
+    if(!PyArg_ParseTuple(args, "O|i", &handle, &oswitch))
     {
         return NULL;
     }
     TextParser*              tp = static_cast<TextParser*>(PyCObject_AsVoidPtr(handle));
 
     std::vector<std::string> labels;
-    int                      ret       = tp->getNodes(labels);
+    int                      ret       = tp->getNodes(labels, oswitch);
     PyObject*                py_labels = PyList_New(labels.size());
     int                      i         = 0;
     for(std::vector<std::string>::iterator it = labels.begin(); it != labels.end(); ++it)
@@ -203,14 +204,15 @@ static PyObject* TextParser_getNodes(PyObject* self, PyObject* args)
 static PyObject* TextParser_getLabels(PyObject* self, PyObject* args)
 {
     PyObject* handle;
-    if(!PyArg_ParseTuple(args, "O", &handle))
+    int oswitch=0;
+    if(!PyArg_ParseTuple(args, "O|i", &handle, &oswitch))
     {
         return NULL;
     }
     TextParser*              tp = static_cast<TextParser*>(PyCObject_AsVoidPtr(handle));
 
     std::vector<std::string> labels;
-    int                      ret       = tp->getLabels(labels);
+    int                      ret       = tp->getLabels(labels, oswitch);
     PyObject*                py_labels = PyList_New(labels.size());
     int                      i         = 0;
     for(std::vector<std::string>::iterator it = labels.begin(); it != labels.end(); ++it)

--- a/python_api/test.py
+++ b/python_api/test.py
@@ -38,11 +38,23 @@ print tp.currentNode(instance)
 print "test for getNodes()"
 print tp.getNodes(instance)
 
+print "test for getNodes() with option parameter 1"
+print tp.getNodes(instance, 1)
+
+print "test for getNodes() with option parameter 2"
+print tp.getNodes(instance, 2)
+
 print "test for changeNode()"
 print tp.changeNode(instance, 'config')
 
 print "test for getLabels()"
 print tp.getLabels(instance)
+
+print "test for getLabels() with option parameter 1"
+print tp.getLabels(instance, 1)
+
+print "test for getLabels() with option parameter 2"
+print tp.getLabels(instance, 2)
 
 print "test for createLeaf()"
 print tp.createLeaf(instance, 'foo', '"bar"')


### PR DESCRIPTION
getNodes()とgetLabelsのオプション引数oswitchを渡せるようにラッパールーチン側の引数を変更しました。
