### PR TITLE
Use canonical way to detect stdbool.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -235,7 +235,7 @@ AC_CHECK_HEADERS([stdlib.h string.h])
 #
 # Checks for typedefs, structures, and compiler characteristics.
 #
-AC_CHECK_HEADER_STDBOOL
+AC_HEADER_STDBOOL
 AC_C_INLINE
 AC_TYPE_SIZE_T
 


### PR DESCRIPTION
`AC_CHECK_HEADER_STDBOOL` is non canonical way to detect stdbool.h or C99 feature, and `autoreconf` fails when rebuilding `configure`.

`AC_HEADER_STDBOOL` is the canonical way and better to use it for a portability.

https://www.gnu.org/software/autoconf/manual/autoconf-2.63/html_node/Particular-Headers.html